### PR TITLE
Find keywords without lowering the keywords from the results file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,4 +4,5 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #7 Fix Winlab Instrument by not lowering keywords
 - First version of `senaite.instruments`

--- a/src/senaite/instruments/tests/test_perkinelmer_winlab32.py
+++ b/src/senaite/instruments/tests/test_perkinelmer_winlab32.py
@@ -67,14 +67,14 @@ class TestWinlab32(BaseTestCase):
         self.services = [
             self.add_analysisservice(
                 title='Ag 107',
-                Keyword='ag107',
+                Keyword='Ag107',
                 PointOfCapture='lab',
                 Category=self.add_analysiscategory(title='Metals'),
                 Calculation='Dilution',
                 InterimFields=service_interims),
             self.add_analysisservice(
                 title='al 27',
-                Keyword='al27',
+                Keyword='Al27',
                 PointOfCapture='lab',
                 Category=self.add_analysiscategory(title='Metals'),
                 Calculation='Dilution',
@@ -102,8 +102,8 @@ class TestWinlab32(BaseTestCase):
             instrument_results_file=import_file,
             instrument=api.get_uid(self.instrument)))
         results = importer.Import(self.portal, request)
-        ag = ar.getAnalyses(full_objects=True, getKeyword='ag107')[0]
-        al = ar.getAnalyses(full_objects=True, getKeyword='al27')[0]
+        ag = ar.getAnalyses(full_objects=True, getKeyword='Ag107')[0]
+        al = ar.getAnalyses(full_objects=True, getKeyword='Al27')[0]
         test_results = eval(results)  # noqa
         self.assertEqual(ag.getResult(), '0.111')
         self.assertEqual(al.getResult(), '0.222')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.instruments/issues/6

## Current behavior before PR
The code does a .lower() to keyword and does not match the expected keyword and does not update the results or just change the keywords on the test senaite/instruments/tests/test_perkinelmer_winlab32.py to start with capital letters(ag107 to Ag107) and run the test.

## Desired behavior after PR is merged
Keywords should match and the result must be updated.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
