### PR TITLE
Find keyworks for nexion350x without lowering the keywords from the

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,5 +3,5 @@ Changelog
 
 1.0.0 (unreleased)
 ------------------
-
+- #8 Fix nexion350x Instrument by not lowering keywords
 - First version of `senaite.instruments`

--- a/src/senaite/instruments/tests/test_perkinelmer_nexion_350x.py
+++ b/src/senaite/instruments/tests/test_perkinelmer_nexion_350x.py
@@ -66,13 +66,13 @@ class TestNexion350X(BaseTestCase):
 
         self.services = [
             self.add_analysisservice(title='Ag 107',
-                                     Keyword='ag107',
+                                     Keyword='Ag107',
                                      PointOfCapture='lab',
                                      Category='Metals',
                                      Calculation='Dilution',
                                      InterimFields=service_interims),
             self.add_analysisservice(title='al 27',
-                                     Keyword='al27',
+                                     Keyword='Al27',
                                      PointOfCapture='lab',
                                      Category='Metals',
                                      Calculation='Dilution',
@@ -111,10 +111,10 @@ class TestNexion350X(BaseTestCase):
             instrument=api.get_uid(self.instrument)))
         results = importer.Import(self.portal, request)
         test_results = eval(results)  # noqa
-        ag1 = ar1.getAnalyses(full_objects=True, getKeyword='ag107')[0]
-        al1 = ar1.getAnalyses(full_objects=True, getKeyword='al27')[0]
-        ag2 = ar2.getAnalyses(full_objects=True, getKeyword='ag107')[0]
-        al2 = ar2.getAnalyses(full_objects=True, getKeyword='al27')[0]
+        ag1 = ar1.getAnalyses(full_objects=True, getKeyword='Ag107')[0]
+        al1 = ar1.getAnalyses(full_objects=True, getKeyword='Al27')[0]
+        ag2 = ar2.getAnalyses(full_objects=True, getKeyword='Ag107')[0]
+        al2 = ar2.getAnalyses(full_objects=True, getKeyword='Al27')[0]
         self.assertEqual(ag1.getResult(), '0.111')
         self.assertEqual(al1.getResult(), '0.555')
         self.assertEqual(ag2.getResult(), '0.222')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.instruments/issues/6

## Current behavior before PR
The code does a .lower() to keyword and does not match the expected keyword and does not update the results or just change the keywords on the test senaite/instruments/tests/test_perkinelmer_nexion_350x.py to start with capital letters(ag107 to Ag107) and run the test.

## Desired behavior after PR is merged
Keywords should match and the result must be updated.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
